### PR TITLE
Remove needs condition on publish-docs

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -83,7 +83,6 @@ jobs:
 
     publish-docs:
         if: github.event_name == 'push'
-        needs: [pre-commit-hooks, build]
         runs-on: ubuntu-latest
         defaults:
             run:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ xCDAT
 Xarray Extended with Climate Data Analysis Tools
 
 -  Free software: MIT license
--  Documentation: https://xcdat.readthedocs.io
+-  Documentation: https://tomvothecoder.github.io/xcdat/
 
 .. |Anaconda-Server Badge| image:: https://anaconda.org/tomvothecoder/xcdat/badges/version.svg
    :target: https://anaconda.org/tomvothecoder/xcdat


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR removes the needs condition to publish docs, which caused the step not to run once a PR was merged.

## How Has This Been Tested?
<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
