### PR TITLE
Fix Python 3.8 typing_extensions import error

### DIFF
--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -1,9 +1,8 @@
 import glob
 import os
-from typing import Dict, Tuple, get_args
+from typing import Dict, Literal, Tuple, get_args
 
 import xarray as xr
-from typing_extensions import Literal
 
 # Add supported extensions on as-need basis
 # https://xarray.pydata.org/en/stable/io.html#


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR fixes a typing extension issue related to switching from Python 3.7 to 3.8

- Closes #<ISSUE_NUMBER_HERE>

## How Has This Been Tested?
<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
