### PR TITLE
Add typing_extensions to dependencies

### DIFF
--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -8,6 +8,7 @@ dependencies:
     # ==================
     - python=3.8.8
     - pip=21.0.1
+    - typing_extensions=3.7.4 # Required to make use of Python >=3.8 backported types
     - cartopy=0.18.0
     - matplotlib=3.3.4
     - netcdf4=1.5.6

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -8,6 +8,7 @@ dependencies:
     # ==================
     - python=3.8.8
     - pip=21.0.1
+    - typing_extensions=3.7.4 # Required to make use of Python >=3.8 backported types
     - cartopy=0.18.0
     - matplotlib=3.3.4
     - netcdf4=1.5.6

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
 
   run:
     - python
+    - typing_extensions
     - cartopy
     - matplotlib
     - netcdf4


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds `typing_extensions` as an explicit dependency in all conda yaml files.

`typing_extensions` was implicitly added by another dependency. The RTD conda yml did not capture `typing_extensions`, so the RTD build fails.

- Closes N/A


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
