### PR TITLE
Add anaconda channel label assignment in release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -35,13 +35,21 @@ jobs:
 
             - name: Additional Conda Config
               run: |
-                  conda install anaconda-client conda-build conda-verify
                   conda config --set anaconda_upload no
 
             - name: Build Conda Package
-              run: conda build -c conda-forge --output-folder conda-build conda-recipe
+              run: conda build -c conda-forge --output-folder . .
 
             - name: Publish to Anaconda
               env:
                   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
-              run: anaconda upload conda-build/noarch/*.tar.bz2 --label main --force
+              run: |
+                  label="main"
+                  for file in noarch/*.tar.bz2; do
+                      if [[ "$file" == noarch/*"rc"*.tar.bz2 ]]; then
+                      label="rc"
+                      fi
+                  done
+
+                  echo Uploading to conda-forge with \'$label\' label
+                  anaconda upload --label $label noarch/*.tar.bz2 --force

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -51,5 +51,5 @@ jobs:
                       fi
                   done
 
-                  echo Uploading to conda-forge with \'$label\' label
+                  echo Uploading with \'$label\' label
                   anaconda upload --label $label noarch/*.tar.bz2 --force


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds logic to the release workflow to assign labels based on the version of the release.
* If `rc` is in the version, release with `rc` label
* If `rc` is not in the version, release with `main` label (default)

- Closes #75 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
