### PR TITLE
Fix axis attrs dropping after generating bounds

### DIFF
--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -164,9 +164,9 @@ class AxisAccessor:
         self._dataset[var_name] = xr.DataArray(
             name=var_name,
             data=bounds,
-            coords={axis: axis_coords.data},
+            coords={axis: axis_coords},
             dims=[axis, "bnds"],
-            attrs={"units": axis_coords.units, "is_generated": True},
+            attrs={**axis_coords.attrs, "is_generated": True},
         )
         return self._dataset[var_name]
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes axis coordinate attributes dropping after generating bounds when bounds don't exist.

This bug was due to the coords data being assigned to the coords of the bounds var, and not the coords DataArray itself.

- Closes #78 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
