### PR TITLE
Separate getting and guessing bounds to avoid implicit side effects

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -2,7 +2,14 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from tests.fixtures import generate_dataset, ts_cf, ts_with_bnds_from_parent_cf
+from tests.fixtures import (
+    generate_dataset,
+    lat_bnds,
+    lon_bnds,
+    time_bnds,
+    ts_cf,
+    ts_with_bnds_from_parent_cf,
+)
 from xcdat.bounds import DataArrayBoundsAccessor, DatasetBoundsAccessor
 
 
@@ -10,6 +17,7 @@ class TestDatasetBoundsAccessor:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=False)
+        self.ds_with_bnds = generate_dataset(cf_compliant=True, has_bounds=True)
 
     def test__init__(self):
         obj = DatasetBoundsAccessor(self.ds)
@@ -18,8 +26,37 @@ class TestDatasetBoundsAccessor:
     def test_decorator_call(self):
         assert self.ds.bounds._dataset.identical(self.ds)
 
+    def test_bounds_property_returns_map_of_coordinate_key_to_bounds_dataarray(self):
+        ds = self.ds_with_bnds.copy()
+        expected = {
+            "T": ds.time,
+            "X": ds.lon,
+            "Y": ds.lat,
+            "lat": ds.lat,
+            "latitude": ds.lat,
+            "lon": ds.lon,
+            "longitude": ds.lon,
+            "time": ds.time,
+        }
+
+        result = ds.bounds.bounds
+
+        assert result == expected
+
+    def test_fill_missing_returns_dataset_with_filled_bounds(self):
+        ds = self.ds_with_bnds.copy()
+
+        ds = ds.drop_vars(["lat_bnds", "lon_bnds"])
+
+        result = ds.bounds.fill_missing()
+        assert result.identical(self.ds_with_bnds)
+
+    def test_get_bounds_returns_error_when_bounds_dont_exist(self):
+        with pytest.raises(KeyError):
+            self.ds.bounds.get_bounds("lat")
+
     def test_get_bounds_when_bounds_exist_in_dataset(self):
-        ds = generate_dataset(cf_compliant=True, has_bounds=True)
+        ds = self.ds_with_bnds.copy()
         lat_bnds = ds.bounds.get_bounds("lat")
         assert lat_bnds.identical(ds.lat_bnds)
 
@@ -28,41 +65,23 @@ class TestDatasetBoundsAccessor:
         assert lon_bnds.is_generated
 
     def test_get_bounds_when_bounds_do_not_exist_in_dataset(self):
-        ds = self.ds.copy()
+        ds = self.ds_with_bnds.copy()
 
-        lat_bnds = ds.bounds.get_bounds("lat")
-        assert lat_bnds is not None
-        assert lat_bnds.identical(ds.lat_bnds)
-        assert lat_bnds.is_generated
-
-        lon_bnds = ds.bounds.get_bounds("lon")
-        assert lon_bnds is not None
-        assert lon_bnds.identical(ds.lon_bnds)
-        assert lon_bnds.is_generated
-
-        # Check raises error when bounds do not exist and not allowing generated bounds.
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             ds = ds.drop_vars(["lat_bnds"])
-            ds.bounds.get_bounds("lat", allow_generating=False)
+            ds.bounds.get_bounds("lat")
 
-    def test_get_bounds_raises_error_with_incorrect_axis_argument(self):
+    def test_get_bounds_raises_error_with_incorrect_coord_argument(self):
         with pytest.raises(ValueError):
-            self.ds.bounds.get_bounds("incorrect_axis_argument")
+            self.ds.bounds.get_bounds("incorrect_coord_argument")
 
-    def test__get_bounds_does_not_drop_attrs_of_existing_coords_when_generating_bounds(
-        self,
-    ):
-        ds_expected = self.ds.copy()
-        ds_expected["lat"].attrs["bounds"] = "lat_bnds"
+    def test_add_bounds_raises_error_if_bounds_exist(self):
+        ds = self.ds_with_bnds.copy()
 
-        ds_result = self.ds.copy()
-        lat_bnds = ds_result.bounds.get_bounds("lat", allow_generating=True)
-        assert lat_bnds.identical(ds_result.lat_bnds)
+        with pytest.raises(ValueError):
+            ds.bounds.add_bounds("lat")
 
-        ds_result = ds_result.drop_vars("lat_bnds")
-        assert ds_result.identical(ds_expected)
-
-    def test__generate_bounds_raises_errors_for_data_dim_and_length(self):
+    def test__add_bounds_raises_errors_for_data_dim_and_length(self):
         # Multidimensional
         lat = xr.DataArray(
             data=np.array([[0, 1, 2], [3, 4, 5]]),
@@ -79,21 +98,25 @@ class TestDatasetBoundsAccessor:
 
         # If coords dimensions does not equal 1.
         with pytest.raises(ValueError):
-            ds.bounds._generate_bounds("lat")
+            ds.bounds._add_bounds("lat")
         # If coords are length of <=1.
         with pytest.raises(ValueError):
-            ds.bounds._generate_bounds("lon")
+            ds.bounds._add_bounds("lon")
 
-    def test__generate_bounds_returns_bounds(self):
+    def test__add_bounds_returns_dataset_with_bounds_added(self):
         ds = self.ds.copy()
 
-        lat_bnds = ds.bounds._generate_bounds("lat")
-        assert lat_bnds.equals(ds.lat_bnds)
+        ds = ds.bounds._add_bounds("lat")
+        assert ds.lat_bnds.equals(lat_bnds)
         assert ds.lat_bnds.is_generated
 
-        lon_bnds = ds.bounds._generate_bounds("lon")
-        assert lon_bnds.equals(ds.lon_bnds)
+        ds = ds.bounds._add_bounds("lon")
+        assert ds.lon_bnds.equals(lon_bnds)
         assert ds.lon_bnds.is_generated
+
+        ds = ds.bounds._add_bounds("time")
+        assert ds.time_bnds.equals(time_bnds)
+        assert ds.time_bnds.is_generated
 
     def test__get_coord(self):
         ds = self.ds.copy()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -24,7 +24,7 @@ class TestOpenDataset:
 
         result_ds = open_dataset(self.file_path)
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.DatasetBoundsAccessor._generate_bounds() for
+        # Refer to xcdat.bounds.DatasetBoundsAccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds["time_bnds"].attrs["units"] = "months since 2000-01-01"
 
@@ -91,7 +91,7 @@ class TestOpenMfDataset:
 
         result_ds = open_mfdataset([self.file_path1, self.file_path2])
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.DatasetBoundsAccessor._generate_bounds() for
+        # Refer to xcdat.bounds.DatasetBoundsAccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds.time_bnds.attrs["units"] = "months since 2000-01-01"
 

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -55,7 +55,7 @@ def open_dataset(path: str, **kwargs: Dict[str, Any]) -> xr.Dataset:
     """
     ds = xr.open_dataset(path, decode_times=False, **kwargs)
     ds = decode_time_units(ds)
-    ds = ds.bounds.get_bounds_for_all_coords()
+    ds = ds.bounds.fill_missing()
 
     return ds
 
@@ -115,7 +115,7 @@ def open_mfdataset(paths: Union[str, List[str]], **kwargs) -> xr.Dataset:
     """
     ds = xr.open_mfdataset(paths, decode_times=False, **kwargs)
     ds = decode_time_units(ds)
-    ds = ds.bounds.get_bounds_for_all_coords()
+    ds = ds.bounds.fill_missing()
 
     return ds
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #93 
- Refactor `DatasetBoundsAccessor.get_bounds()` to seperate methods
- Now includes two separate methods: `get_bounds()` and `set_bounds()`
- Add property `bounds`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
